### PR TITLE
Fix html attribute

### DIFF
--- a/location.py
+++ b/location.py
@@ -6,10 +6,10 @@ def at_html_attribute(attribute, view, locations):
     view_point = locations[0]
     char = ''
     selector_score = 1
-    while((char != ' ' or selector_score != 0) and view_point > -1):
+    while((not char.isspace() or selector_score != 0) and view_point > -1):
         char = view.substr(view_point)
         selector_score = view.score_selector(view_point, 'string')
-        if(char != ' ' or selector_score != 0):
+        if(not char.isspace() or selector_score != 0):
             check_attribute += char
         view_point -= 1
     check_attribute = check_attribute[::-1].replace('(', '')


### PR DESCRIPTION
In order to know if the completion must be triggered, the code must know when the cursor is inside a class attribut in an html file. This commit fix the algorithm used to detect html attributes. The initial algorithm expected that attributes are separated by spaces, but they can be separated by other whitespace characters (such as tabulations). 

Note that, funnily enough, the same algorithm is used by the sublime angular plugin, and I proposed the same change here: https://github.com/angular-ui/AngularJS-sublime-package/pull/72/files